### PR TITLE
Add AAFx — FCPXML to AAF converter for Pro Tools

### DIFF
--- a/docs/_includes/tools/aafx.md
+++ b/docs/_includes/tools/aafx.md
@@ -1,0 +1,45 @@
+### AAFx
+
+Send a Final Cut Pro timeline to Pro Tools without losing a role or a
+timecode. AAFx reads an FCPXML or a `.fcpxmld` bundle and writes a
+self-contained AAF: the audio essence travels inside the file, so the
+mixer can open the session without ever seeing your rushes.
+
+Every role and subrole becomes a named Pro Tools track. Dialogue opens
+the session, then the roles you created in Final Cut, then effects and
+music. Clips of the same role that overlap take neighbouring sub-tracks
+instead of piling up.
+
+Each region carries the source timecode of its own rush, which keeps
+conforming possible months later. When a drive is offline, AAFx names
+every missing file, its role, how many clips use it and the volume it
+expects — then relinks by source timecode and exact duration rather
+than by filename, so two rushes with the same name from different
+shooting days can never be confused.
+
+Pro Tools only reads mono audio essence inside an AAF, which is why an
+interleaved stereo region turns into saturated noise. AAFx splits every
+source into one mono track per channel that actually carries sound, and
+discards silent channels — a 16-track field recording does not flood
+the session with 16 empty tracks.
+
+Multicam clips are resolved to their active audio angles, compound
+clips are expanded, and clips whose audio you disabled in the edit stay
+out of the AAF. Handles are adjustable from zero to thirty seconds.
+
+Nothing is installed on your Mac: Python and the audio extractor travel
+inside the application. No Homebrew, no ffmpeg, no Terminal. Nothing
+leaves your machine.
+
+Requirements
+
+- macOS 11 or later
+- Final Cut Pro 10.4 to 12.3, FCPXML up to 1.14, `.fcpxml` and
+  `.fcpxmld` bundles
+- Pro Tools for AAF import, via File > Import > Session Data
+
+Complete seven-day trial, no watermark and no credit card. One-off
+price, no subscription: 79 € for a single Mac, 139 € for four
+simultaneous floating seats.
+
+[!button text="Visit Website" target="blank" variant="info"](https://aafx.app/)


### PR DESCRIPTION
AAFx converts a Final Cut Pro timeline — an FCPXML file or a `.fcpxmld` bundle — into a self-contained AAF for Pro Tools.

What it does that felt worth adding here:

- Every role and subrole becomes a **named Pro Tools track**, ordered the way a mixer expects: dialogue first, then the roles from the edit, then effects and music.
- Each region keeps the **source timecode of its own rush**, which keeps conforming possible months later.
- Offline media is **relinked by source timecode and exact duration**, never by filename, so two rushes sharing a name from different shooting days can't be swapped.
- Multichannel sources are **split into mono**, because Pro Tools reads interleaved stereo inside an AAF with the wrong stride and turns it into noise.
- Multicam clips are resolved to their active audio angles, compound clips are expanded, and clips whose audio was disabled in the edit stay out.

Reads FCPXML up to 1.14, from Final Cut Pro 10.4 to 12.3. macOS 11+. Nothing is installed — Python and the audio extractor travel inside the app, so no Homebrew, no ffmpeg, no Terminal.

Complete 7-day trial, no watermark, no credit card. One-off price, no subscription.

I'm the developer. Happy to reword anything, or to drop the entry if it isn't a fit for the page.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new tools page for AAFx, an app that converts Final Cut Pro timelines (FCPXML/`.fcpxmld`) into self‑contained AAF files for Pro Tools.

The page outlines role-based track mapping, preserved source timecode with relinking by timecode/duration, mono channel splitting, multicam/compound handling, adjustable handles, supported versions (FCPXML up to 1.14; FCP 10.4–12.3; macOS 11+), and pricing with a Visit Website link.

<sup>Written for commit c7490d24f60eaf637f4aac0cef8f6e9a87b52322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/CommandPost/FCPCafe/pull/550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

